### PR TITLE
[#13] feat : 로그인 요청 시 토큰과 함께 userId와 nickName을 같이 반환하도록 변경함

### DIFF
--- a/ducktem-api/src/main/java/com/ducktem/ducktemapi/controller/MemberController.java
+++ b/ducktem-api/src/main/java/com/ducktem/ducktemapi/controller/MemberController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ducktem.ducktemapi.dto.MemberDto;
-import com.ducktem.ducktemapi.dto.response.TokenResponse;
+import com.ducktem.ducktemapi.dto.response.LoginResponse;
 import com.ducktem.ducktemapi.entity.Member;
 import com.ducktem.ducktemapi.service.MemberService;
 
@@ -25,7 +25,7 @@ public class MemberController {
 	}
 
 	@PostMapping("/login")
-	public ResponseEntity<TokenResponse> login(@RequestBody MemberDto memberDto) {
+	public ResponseEntity<LoginResponse> login(@RequestBody MemberDto memberDto) {
 		return new ResponseEntity<>(memberService.login(memberDto), HttpStatus.OK);
 	}
 

--- a/ducktem-api/src/main/java/com/ducktem/ducktemapi/dto/response/LoginResponse.java
+++ b/ducktem-api/src/main/java/com/ducktem/ducktemapi/dto/response/LoginResponse.java
@@ -1,0 +1,16 @@
+package com.ducktem.ducktemapi.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginResponse {
+	private String userId;
+	private String nickName;
+	private TokenResponse tokenResponse;
+}

--- a/ducktem-api/src/main/java/com/ducktem/ducktemapi/service/MemberService.java
+++ b/ducktem-api/src/main/java/com/ducktem/ducktemapi/service/MemberService.java
@@ -3,7 +3,7 @@ package com.ducktem.ducktemapi.service;
 import java.util.List;
 
 import com.ducktem.ducktemapi.dto.MemberDto;
-import com.ducktem.ducktemapi.dto.response.TokenResponse;
+import com.ducktem.ducktemapi.dto.response.LoginResponse;
 import com.ducktem.ducktemapi.entity.Member;
 
 public interface MemberService {
@@ -11,7 +11,7 @@ public interface MemberService {
 
 	Member join(Member member);
 
-	TokenResponse login(MemberDto memberDto);
+	LoginResponse login(MemberDto memberDto);
 
 	List<Member> getList();
 

--- a/ducktem-api/src/main/java/com/ducktem/ducktemapi/service/MemberServiceImpl.java
+++ b/ducktem-api/src/main/java/com/ducktem/ducktemapi/service/MemberServiceImpl.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.ducktem.ducktemapi.dto.MemberDto;
+import com.ducktem.ducktemapi.dto.response.LoginResponse;
 import com.ducktem.ducktemapi.dto.response.TokenResponse;
 import com.ducktem.ducktemapi.entity.Member;
 import com.ducktem.ducktemapi.entity.MemberStatus;
@@ -52,7 +53,7 @@ public class MemberServiceImpl implements MemberService {
 
 	@Override
 	@Transactional
-	public TokenResponse login(MemberDto memberDto) {
+	public LoginResponse login(MemberDto memberDto) {
 		Member member = valid(memberDto);
 		String refreshJwt = jwtProvider.createRefreshJwt();
 		String accessJwt = jwtProvider.createAccessJwt(member.getUserId());
@@ -62,8 +63,12 @@ public class MemberServiceImpl implements MemberService {
 		} else {
 			existingMember.get().setRefreshToken(refreshJwt);
 		}
-
-		return TokenResponse.from(accessJwt, refreshJwt);
+		TokenResponse token = TokenResponse.from(accessJwt, refreshJwt);
+		return LoginResponse
+			.builder()
+			.nickName(member.getNickName())
+			.userId(member.getNickName())
+			.tokenResponse(token).build();
 	}
 
 	@Override


### PR DESCRIPTION
로그인 후에 웹 브라우저에서 현재 사용자의 닉네임과 아이디를 화면에 출력해야하므로 토큰과 함께 추가적으로 반환하도록 변경하였습니다.

똑같이 로그인 요청을 하면 되고, 반환되는 내용은 아래와 같아요~~~~

### Postman 결과 화면

<img width="901" alt="image" src="https://user-images.githubusercontent.com/104195103/215025035-a1b94bf3-6b67-41a6-80a0-5a6639ec2e34.png">
