### PR TITLE
마이페이지 구현

### DIFF
--- a/ducktem-api/src/main/java/com/ducktem/ducktemapi/config/SecurityConfig.java
+++ b/ducktem-api/src/main/java/com/ducktem/ducktemapi/config/SecurityConfig.java
@@ -42,6 +42,7 @@ public class SecurityConfig {
 			.requestMatchers("/members/me").authenticated()
 			.requestMatchers(HttpMethod.PUT,"/members").authenticated()
 			.requestMatchers(HttpMethod.POST,"/products").authenticated()
+			.requestMatchers("/mypage/**").authenticated()
 			.anyRequest().permitAll()
 			.and()
 			// username,password로 인증하지않고, token 방식으로 하기위해 JwtFilter를 usernamepassword 필터 이전에 실행.

--- a/ducktem-api/src/main/java/com/ducktem/ducktemapi/config/SecurityConfig.java
+++ b/ducktem-api/src/main/java/com/ducktem/ducktemapi/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.ducktem.ducktemapi.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -9,6 +10,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import com.ducktem.ducktemapi.exception.JwtAuthenticationEntryPoint;
 import com.ducktem.ducktemapi.jwt.JwtFilter;
 
 import lombok.RequiredArgsConstructor;
@@ -20,6 +22,8 @@ public class SecurityConfig {
 
 	private final ExceptionHandlerFilter exceptionHandlerFilter;
 
+	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
 	@Bean
 	SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
@@ -29,11 +33,15 @@ public class SecurityConfig {
 			.formLogin().disable()  //formLogin 페이지를 사용하지 않음.
 			.httpBasic().disable()  //http 기본 검증을 사용하지 않음. Bearer 사용
 			.cors().and()  // cors 설정
+			.exceptionHandling()
+			.authenticationEntryPoint(jwtAuthenticationEntryPoint)
+			.and()
 			.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 			.and()
 			.authorizeHttpRequests()
-			.requestMatchers("/members/test").authenticated()
-			// .requestMatchers("/products").authenticated()
+			.requestMatchers("/members/me").authenticated()
+			.requestMatchers(HttpMethod.PUT,"/members").authenticated()
+			.requestMatchers(HttpMethod.POST,"/products").authenticated()
 			.anyRequest().permitAll()
 			.and()
 			// username,password로 인증하지않고, token 방식으로 하기위해 JwtFilter를 usernamepassword 필터 이전에 실행.

--- a/ducktem-api/src/main/java/com/ducktem/ducktemapi/controller/MemberController.java
+++ b/ducktem-api/src/main/java/com/ducktem/ducktemapi/controller/MemberController.java
@@ -2,13 +2,18 @@ package com.ducktem.ducktemapi.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ducktem.ducktemapi.dto.request.LoginRequest;
+import com.ducktem.ducktemapi.dto.request.MemberInfoRequest;
+import com.ducktem.ducktemapi.dto.response.MemberInfoResponse;
 import com.ducktem.ducktemapi.entity.Member;
 import com.ducktem.ducktemapi.service.MemberService;
 
@@ -30,6 +35,18 @@ public class MemberController {
 	public ResponseEntity<Void> withDraw(@RequestBody LoginRequest loginRequest) {
 		memberService.withDraw(loginRequest);
 		return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+	}
+
+	@GetMapping("me")
+	public ResponseEntity<MemberInfoResponse> myInfo(Authentication authentication) {
+
+		return new ResponseEntity<>(memberService.getInfo(authentication.getName()), HttpStatus.OK);
+
+	}
+
+	@PutMapping
+	public ResponseEntity<MemberInfoResponse> updateInfo(@RequestBody MemberInfoRequest memberInfoRequest, Authentication authentication) {
+		return new ResponseEntity<>(memberService.updateInfo(authentication.getName(),memberInfoRequest), HttpStatus.OK);
 	}
 
 	@PostMapping("/members/test")

--- a/ducktem-api/src/main/java/com/ducktem/ducktemapi/controller/MyPageController.java
+++ b/ducktem-api/src/main/java/com/ducktem/ducktemapi/controller/MyPageController.java
@@ -1,0 +1,32 @@
+package com.ducktem.ducktemapi.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.ducktem.ducktemapi.dto.response.ProductPreviewResponse;
+import com.ducktem.ducktemapi.service.MyPageService;
+
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("mypage")
+public class MyPageController {
+	private final MyPageService myPageService;
+	// 찜 기능 구현과 같이 구현 예정.
+	public void myWishList() {
+
+	}
+	@GetMapping()
+	public ResponseEntity<List<ProductPreviewResponse>> mySellProductList(Authentication authentication){
+		return new ResponseEntity<>(myPageService.productList(authentication.getName()), HttpStatus.OK);
+
+	}
+
+}

--- a/ducktem-api/src/main/java/com/ducktem/ducktemapi/dto/request/MemberInfoRequest.java
+++ b/ducktem-api/src/main/java/com/ducktem/ducktemapi/dto/request/MemberInfoRequest.java
@@ -1,0 +1,17 @@
+package com.ducktem.ducktemapi.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+@AllArgsConstructor
+@Builder
+public class MemberInfoRequest {
+	private String nickName;
+	private String intro;
+	private String email;
+	private String profileUrl;
+}

--- a/ducktem-api/src/main/java/com/ducktem/ducktemapi/dto/response/MemberInfoResponse.java
+++ b/ducktem-api/src/main/java/com/ducktem/ducktemapi/dto/response/MemberInfoResponse.java
@@ -1,0 +1,28 @@
+package com.ducktem.ducktemapi.dto.response;
+
+import com.ducktem.ducktemapi.entity.Member;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberInfoResponse {
+	private String nickName;
+	private String intro;
+	private String email;
+	private String profileUrl;
+
+	public static MemberInfoResponse from(Member member) {
+		return MemberInfoResponse.builder()
+			.nickName(member.getNickName())
+			.intro(member.getIntro())
+			.email(member.getEmail())
+			.profileUrl(member.getProfileImg())
+			.build();
+	}
+}

--- a/ducktem-api/src/main/java/com/ducktem/ducktemapi/entity/Member.java
+++ b/ducktem-api/src/main/java/com/ducktem/ducktemapi/entity/Member.java
@@ -1,5 +1,8 @@
 package com.ducktem.ducktemapi.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -7,6 +10,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
@@ -48,5 +52,7 @@ public class Member {
 	private float level;
 	@Enumerated(EnumType.STRING)
 	private MemberStatus status;
+	@OneToMany(mappedBy = "member")
+	private List<Product> productList = new ArrayList<>();
 
 }

--- a/ducktem-api/src/main/java/com/ducktem/ducktemapi/entity/Product.java
+++ b/ducktem-api/src/main/java/com/ducktem/ducktemapi/entity/Product.java
@@ -67,5 +67,11 @@ public class Product {
 	@Enumerated(EnumType.STRING)
 	private SalesStatus salesStatus;
 
+	public void setMember(Member member) {
+		this.member = member;
+		if(!member.getProductList().contains(this)) {
+			member.getProductList().add(this);
+		}
+	}
 }
 

--- a/ducktem-api/src/main/java/com/ducktem/ducktemapi/exception/JwtAuthenticationEntryPoint.java
+++ b/ducktem-api/src/main/java/com/ducktem/ducktemapi/exception/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,30 @@
+package com.ducktem.ducktemapi.exception;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+	private static final String ERROR_MESSAGE = "로그인이 필요합니다.";
+
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException authException) throws IOException {
+		response.setStatus(HttpStatus.UNAUTHORIZED.value());
+		response.setContentType("application/json");
+		response.setCharacterEncoding("UTF-8");
+		response.getWriter().write(ERROR_MESSAGE);
+	}
+
+}

--- a/ducktem-api/src/main/java/com/ducktem/ducktemapi/service/MemberService.java
+++ b/ducktem-api/src/main/java/com/ducktem/ducktemapi/service/MemberService.java
@@ -3,6 +3,8 @@ package com.ducktem.ducktemapi.service;
 import java.util.List;
 
 import com.ducktem.ducktemapi.dto.request.LoginRequest;
+import com.ducktem.ducktemapi.dto.request.MemberInfoRequest;
+import com.ducktem.ducktemapi.dto.response.MemberInfoResponse;
 import com.ducktem.ducktemapi.entity.Member;
 
 public interface MemberService {
@@ -14,4 +16,7 @@ public interface MemberService {
 
 	List<Member> getList();
 
+	MemberInfoResponse getInfo(String name);
+
+	MemberInfoResponse updateInfo(String userId, MemberInfoRequest memberInfoRequest);
 }

--- a/ducktem-api/src/main/java/com/ducktem/ducktemapi/service/MemberServiceImpl.java
+++ b/ducktem-api/src/main/java/com/ducktem/ducktemapi/service/MemberServiceImpl.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.ducktem.ducktemapi.dto.request.LoginRequest;
+import com.ducktem.ducktemapi.dto.request.MemberInfoRequest;
+import com.ducktem.ducktemapi.dto.response.MemberInfoResponse;
 import com.ducktem.ducktemapi.entity.Member;
 import com.ducktem.ducktemapi.entity.MemberStatus;
 import com.ducktem.ducktemapi.exception.MemberException;
@@ -62,7 +64,29 @@ public class MemberServiceImpl implements MemberService {
 		return null;
 	}
 
+	@Override
+	public MemberInfoResponse getInfo(String userId) {
+		return memberRepository.findByUserId(userId)
+			.map(MemberInfoResponse::from)
+			.orElseThrow(() -> new MemberException("잘못된 접근입니다."));
+	}
 
+	@Override
+	@Transactional
+	public MemberInfoResponse updateInfo(String userId,MemberInfoRequest memberInfoRequest) {
+		Member member = memberRepository.findByUserId(userId)
+			.orElseThrow(() -> new MemberException("잘못된 접근입니다."));
+
+		Optional.ofNullable(memberInfoRequest.getEmail())
+			.ifPresent(member::setEmail);
+		Optional.ofNullable(memberInfoRequest.getNickName())
+			.ifPresent(member::setNickName);
+		Optional.ofNullable(memberInfoRequest.getIntro())
+			.ifPresent(member::setIntro);
+
+		return MemberInfoResponse.from(member);
+
+	}
 
 	// 회원가입시 id,nickname을 확인 한 후 기존 아이디가 존재한다면 예외를 발생시킴
 	@Transactional

--- a/ducktem-api/src/main/java/com/ducktem/ducktemapi/service/MyPageService.java
+++ b/ducktem-api/src/main/java/com/ducktem/ducktemapi/service/MyPageService.java
@@ -1,0 +1,9 @@
+package com.ducktem.ducktemapi.service;
+
+import java.util.List;
+
+import com.ducktem.ducktemapi.dto.response.ProductPreviewResponse;
+
+public interface MyPageService {
+	List<ProductPreviewResponse> productList(String userId);
+}

--- a/ducktem-api/src/main/java/com/ducktem/ducktemapi/service/MyPageServiceImpl.java
+++ b/ducktem-api/src/main/java/com/ducktem/ducktemapi/service/MyPageServiceImpl.java
@@ -1,0 +1,26 @@
+package com.ducktem.ducktemapi.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.ducktem.ducktemapi.dto.response.ProductPreviewResponse;
+import com.ducktem.ducktemapi.entity.Member;
+import com.ducktem.ducktemapi.exception.MemberException;
+import com.ducktem.ducktemapi.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageServiceImpl implements MyPageService {
+	private final MemberRepository memberRepository;
+
+	@Override
+	public List<ProductPreviewResponse> productList(String userId) {
+		Member member = memberRepository.findByUserId(userId).orElseThrow(() -> new MemberException("잘못된 접근입니다."));
+
+		return member.getProductList().stream().map(ProductPreviewResponse::from).toList();
+
+	}
+}


### PR DESCRIPTION
마이페이지를 만들고 나니까 뭔가 이상한 점이 있어서 회의 요청합니다~🙏🏻🙏🏻

- 멤버 정보 조회, 수정 기능 추가 -> url은 member/me 입니다! put은 수정, get은 조회 요청이에요
- 멤버 수정 후 수정한 정보가 반환됩니다.
- 내 상품 리스트 구현 -> url은 mypage 입니다!
- 인증이 필요한 서비스 요청 시 헤더의 Authorization 없이 요청하면 "로그인이 필요한 서비스입니다" 라고 응답합니다.
- 상품등록, 내 정보 수정, 내 정보 조회 전부 다 인증 요청 설정해뒀습니다! 앞으로 요청하실때는 꼭 토큰과 함께 보내주세요!!

## PostMan 결과
1. 회원 정보 조회
![image](https://user-images.githubusercontent.com/104195103/215278928-f52d0f0e-00d0-4663-b3a9-76062bba87b4.png)

2. 회원 정보 수정
![image](https://user-images.githubusercontent.com/104195103/215279013-c0bea73f-5c95-4ae1-b52b-83e2b19d30a4.png)
- 사용자가 데이터를 넣지 않으면 기존 정보 유지합니다

3. 내 상품 조회
![image](https://user-images.githubusercontent.com/104195103/215279154-23af07cc-6caa-44f0-8fa0-31d618adbb0c.png)

### 회의 요청 내용은 Mypage URL을 어떻게 해야할지 모르겠어요 😂😂