### PR TITLE
상품 디테일 정보 추가 구현

### DIFF
--- a/ducktem-api/src/main/java/com/ducktem/ducktemapi/dto/response/ProductDetailResponse.java
+++ b/ducktem-api/src/main/java/com/ducktem/ducktemapi/dto/response/ProductDetailResponse.java
@@ -1,6 +1,7 @@
 package com.ducktem.ducktemapi.dto.response;
 
 import java.util.List;
+import java.util.Objects;
 
 import com.ducktem.ducktemapi.entity.Product;
 import com.ducktem.ducktemapi.entity.SalesStatus;
@@ -26,7 +27,9 @@ public class ProductDetailResponse {
 	private List<ProductTagResponse> tags;
 	private String subCategory;
 	private String superCategory;
-	private String regMemberId;
+	private MemberInfoResponse regMemberInfo;
+	private List<ProductPreviewResponse> otherProducts;
+	private int otherProductsSize;
 	private SalesStatus salesStatus;
 
 	public static ProductDetailResponse from(Product product) {
@@ -41,7 +44,12 @@ public class ProductDetailResponse {
 			.superCategory(product.getCategory().getSuperCategory().getName())
 			.subCategory(product.getCategory().getName())
 			.tags(ProductTagResponse.from(product.getTag()))
-			.regMemberId(product.getMember().getUserId())
+			.regMemberInfo(MemberInfoResponse.from(product.getMember()))
+			.otherProducts(ProductPreviewResponse.fromList(product.getMember()
+				.getProductList()
+				.stream()
+				.filter(memberProduct -> !Objects.equals(memberProduct.getId(), product.getId())).toList()))
+			.otherProductsSize(product.getMember().getProductList().size())
 			.salesStatus(product.getSalesStatus())
 			.build();
 	}

--- a/ducktem-api/src/main/java/com/ducktem/ducktemapi/dto/response/ProductDetailResponse.java
+++ b/ducktem-api/src/main/java/com/ducktem/ducktemapi/dto/response/ProductDetailResponse.java
@@ -11,12 +11,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class ProductDetailResponse {
+	private Long id;
 	private String name;
 	private Long price;
 	private String description;
@@ -28,12 +30,16 @@ public class ProductDetailResponse {
 	private String subCategory;
 	private String superCategory;
 	private MemberInfoResponse regMemberInfo;
+	@Setter
 	private List<ProductPreviewResponse> otherProducts;
 	private int otherProductsSize;
 	private SalesStatus salesStatus;
+	@Setter
+	private int wishStatus;
 
 	public static ProductDetailResponse from(Product product) {
 		return ProductDetailResponse.builder()
+			.id(product.getId())
 			.name(product.getName())
 			.price(product.getPrice())
 			.description(product.getDescription())

--- a/ducktem-api/src/main/java/com/ducktem/ducktemapi/dto/response/ProductPreviewResponse.java
+++ b/ducktem-api/src/main/java/com/ducktem/ducktemapi/dto/response/ProductPreviewResponse.java
@@ -1,5 +1,7 @@
 package com.ducktem.ducktemapi.dto.response;
 
+import java.util.List;
+
 import com.ducktem.ducktemapi.dto.WishStatusDto;
 import com.ducktem.ducktemapi.entity.Product;
 import com.ducktem.ducktemapi.entity.ProductImage;
@@ -41,6 +43,10 @@ public class ProductPreviewResponse {
                 .salesStatus(product.getSalesStatus())
                 .wishStatus(new WishStatusDto().getWishStatus())
                 .build();
+    }
+
+    public static List<ProductPreviewResponse> fromList(List<Product> products) {
+        return products.stream().map(ProductPreviewResponse::from).toList();
     }
 
 }

--- a/ducktem-api/src/main/java/com/ducktem/ducktemapi/dto/response/ProductPreviewResponse.java
+++ b/ducktem-api/src/main/java/com/ducktem/ducktemapi/dto/response/ProductPreviewResponse.java
@@ -2,51 +2,52 @@ package com.ducktem.ducktemapi.dto.response;
 
 import java.util.List;
 
-import com.ducktem.ducktemapi.dto.WishStatusDto;
 import com.ducktem.ducktemapi.entity.Product;
 import com.ducktem.ducktemapi.entity.ProductImage;
 import com.ducktem.ducktemapi.entity.SalesStatus;
 import com.ducktem.ducktemapi.util.TimeFormatter;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class ProductPreviewResponse {
-    private Long productId;
-    private String name;
-    private Long price;
-    private String regDate;
-    private SalesStatus salesStatus;
-    private String thumbNail;
-    @Setter
-    private int wishStatus;
+	private Long productId;
+	private String name;
+	private Long price;
+	private String regDate;
+	private SalesStatus salesStatus;
+	private String thumbNail;
+	@Setter
+	private int wishStatus;
 
+	// 상품 정보에서 필요한 데이터만 취합하여 생성.
+	public static ProductPreviewResponse from(Product product) {
+		return ProductPreviewResponse.builder()
+			.productId(product.getId())
+			.name(product.getName())
+			.price(product.getPrice())
+			.regDate(TimeFormatter.nTimeAgo(product.getRegDate()))
+			.thumbNail(product
+				.getProductImageList()
+				.stream()
+				.filter(image -> image.getThumbNail() == (byte)1)
+				.findFirst()
+				.orElseGet(ProductImage::new)
+				// .orElseThrow(() -> new ProductException("데이터 오륲"))
+				.getName())
+			.salesStatus(product.getSalesStatus())
+			.build();
+	}
 
-    // 상품 정보에서 필요한 데이터만 취합하여 생성.
-    public static ProductPreviewResponse from(Product product) {
-        return ProductPreviewResponse.builder()
-                .productId(product.getId())
-                .name(product.getName())
-                .price(product.getPrice())
-                .regDate(TimeFormatter.nTimeAgo(product.getRegDate()))
-                .thumbNail(product
-                        .getProductImageList()
-                        .stream()
-                        .filter(image -> image.getThumbNail() == (byte) 1)
-                        .findFirst()
-                        .orElseGet(ProductImage::new)
-                        // .orElseThrow(() -> new ProductException("데이터 오륲"))
-                        .getName())
-                .salesStatus(product.getSalesStatus())
-                .wishStatus(new WishStatusDto().getWishStatus())
-                .build();
-    }
-
-    public static List<ProductPreviewResponse> fromList(List<Product> products) {
-        return products.stream().map(ProductPreviewResponse::from).toList();
-    }
+	public static List<ProductPreviewResponse> fromList(List<Product> products) {
+		return products.stream().map(ProductPreviewResponse::from).toList();
+	}
 
 }


### PR DESCRIPTION
상품 디테일 요청 시 반환하는 데이터 추가로 구현했습니다.
- 해당 상품을 판매하는 회원의 다른 판매 상품 정보(현재 보고있는 상품은 제외하고 반환합니다~)
- 상품을 판매하는 회원 정보 및 판매하고 있는 상품 갯수
- 판매자의 다른 상품 리스트와 현재 상품 좋아요 상태

점점 수정해야할 코드들이 많아지는거같아요!
일단 구현을 완성 시킨 후에 천천히 리팩토링도 한번 진행해 봐요!